### PR TITLE
Replaced checkCaller() call with equivalent

### DIFF
--- a/src/qukeys/Qukeys.cpp
+++ b/src/qukeys/Qukeys.cpp
@@ -29,8 +29,11 @@ bool Plugin::keyswitchEventHook(KeyswitchEvent& event,
   }
 
   // If Qukeys has already processed this event:
-  if (checkCaller(caller))
+  if (caller != nullptr) {
+    if (caller == this)
+      caller = nullptr;
     return true;
+  }
 
   // If the key toggled on
   if (event.state.toggledOn()) {


### PR DESCRIPTION
I'm probably going to remove `checkCaller()` because it's not really very useful for the
majority of plugins, for which I've come up with a better system.