### PR TITLE
Rename KeyswitchEvent & KeyswitchState structures

### DIFF
--- a/src/qukeys/Qukeys.cpp
+++ b/src/qukeys/Qukeys.cpp
@@ -9,7 +9,7 @@
 #include KALEIDOGLYPH_KEYADDR_H
 #include <kaleidoglyph/Key.h>
 #include <kaleidoglyph/Plugin.h>
-#include <kaleidoglyph/KeyswitchState.h>
+#include <kaleidoglyph/KeyState.h>
 #include <kaleidoglyph/KeyArray.h>
 #include <kaleidoglyph/KeyswitchEvent.h>
 
@@ -68,7 +68,7 @@ bool Plugin::keyswitchEventHook(KeyswitchEvent& event,
     } else {
       flushQueue(false);
       // send release event for the just-released key
-      event.state = cKeyswitchState::released;
+      event.state = cKeyState::released;
       controller_.handleKeyswitchEvent(event, this);
       return true;
     }
@@ -92,7 +92,7 @@ void Plugin::preScanHook(uint16_t current_time) {
     KeyswitchEvent event;
     event.addr  = key_queue_[0].addr;
     event.key   = cKey::clear;
-    event.state = cKeyswitchState::released;
+    event.state = cKeyState::released;
     flushQueue(false);
     controller_.handleKeyswitchEvent(event, this); // send the release event
   }
@@ -179,7 +179,7 @@ void Plugin::flushKey(bool alt_key) {
     event.key = queue_head_p_->primary;
   }
   event.addr  = entry.addr;
-  event.state = cKeyswitchState::pressed;
+  event.state = cKeyState::pressed;
   controller_.handleKeyswitchEvent(event, this);
   //shiftQueue();
   queue_head_p_ = lookupQukey(key_queue_[0]);

--- a/src/qukeys/Qukeys.cpp
+++ b/src/qukeys/Qukeys.cpp
@@ -68,7 +68,7 @@ bool Plugin::keyswitchEventHook(KeyEvent& event,
     } else {
       flushQueue(false);
       // send release event for the just-released key
-      event.state = cKeyState::released;
+      event.state = cKeyState::release;
       controller_.handleKeyEvent(event, this);
       return true;
     }
@@ -92,7 +92,7 @@ void Plugin::preScanHook(uint16_t current_time) {
     KeyEvent event;
     event.addr  = key_queue_[0].addr;
     event.key   = cKey::clear;
-    event.state = cKeyState::released;
+    event.state = cKeyState::release;
     flushQueue(false);
     controller_.handleKeyEvent(event, this); // send the release event
   }
@@ -179,7 +179,7 @@ void Plugin::flushKey(bool alt_key) {
     event.key = queue_head_p_->primary;
   }
   event.addr  = entry.addr;
-  event.state = cKeyState::pressed;
+  event.state = cKeyState::press;
   controller_.handleKeyEvent(event, this);
   //shiftQueue();
   queue_head_p_ = lookupQukey(key_queue_[0]);

--- a/src/qukeys/Qukeys.cpp
+++ b/src/qukeys/Qukeys.cpp
@@ -11,7 +11,7 @@
 #include <kaleidoglyph/Plugin.h>
 #include <kaleidoglyph/KeyState.h>
 #include <kaleidoglyph/KeyArray.h>
-#include <kaleidoglyph/KeyswitchEvent.h>
+#include <kaleidoglyph/KeyEvent.h>
 
 
 namespace kaleidoglyph {
@@ -19,7 +19,7 @@ namespace qukeys {
 
 
 // Event handler
-bool Plugin::keyswitchEventHook(KeyswitchEvent& event,
+bool Plugin::keyswitchEventHook(KeyEvent& event,
                                 kaleidoglyph::Plugin*& caller) {
   // If this plugin isn't active:
   if (! plugin_active_) {
@@ -69,7 +69,7 @@ bool Plugin::keyswitchEventHook(KeyswitchEvent& event,
       flushQueue(false);
       // send release event for the just-released key
       event.state = cKeyState::released;
-      controller_.handleKeyswitchEvent(event, this);
+      controller_.handleKeyEvent(event, this);
       return true;
     }
   }
@@ -89,12 +89,12 @@ void Plugin::preScanHook(uint16_t current_time) {
   // Next, we check the first key in the queue for delayed release
   int16_t diff_time = key_queue_[0].start_time - current_time;
   if (diff_time > 0 && diff_time < int16_t(grace_period_offset - qukey_release_delay_)) {
-    KeyswitchEvent event;
+    KeyEvent event;
     event.addr  = key_queue_[0].addr;
     event.key   = cKey::clear;
     event.state = cKeyState::released;
     flushQueue(false);
-    controller_.handleKeyswitchEvent(event, this); // send the release event
+    controller_.handleKeyEvent(event, this); // send the release event
   }
 
   // Last, we check keys in the queue for hold timeout
@@ -170,7 +170,7 @@ void Plugin::flushKey(bool alt_key) {
   assert(key_queue_length_ > 0);
   QueueEntry entry = shiftQueue();
   // WARNING: queue_head_p_ doesn't reflect key_queue_[0] here
-  KeyswitchEvent event;
+  KeyEvent event;
   if (queue_head_p_ == nullptr) {
     event.key = keymap_[entry.addr];
   } else if (alt_key) {
@@ -180,7 +180,7 @@ void Plugin::flushKey(bool alt_key) {
   }
   event.addr  = entry.addr;
   event.state = cKeyState::pressed;
-  controller_.handleKeyswitchEvent(event, this);
+  controller_.handleKeyEvent(event, this);
   //shiftQueue();
   queue_head_p_ = lookupQukey(key_queue_[0]);
   // WARNING: qukey_release_delay_ out of sync

--- a/src/qukeys/Qukeys.cpp
+++ b/src/qukeys/Qukeys.cpp
@@ -66,10 +66,14 @@ bool Plugin::keyswitchEventHook(KeyEvent& event,
       key_queue_[0].start_time = millis() + grace_period_offset;
       return false;
     } else {
+      // Before we flush the queue, we need to store the Key value for the upcoming
+      // release event (which happens when the current call to handleKeyEvent finishes)
+      if (queue_head_p_ == nullptr) {
+        event.key = keymap_[event.addr];
+      } else {
+        event.key = queue_head_p_->primary;
+      }
       flushQueue(false);
-      // send release event for the just-released key
-      event.state = cKeyState::release;
-      controller_.handleKeyEvent(event, this);
       return true;
     }
   }

--- a/src/qukeys/Qukeys.h
+++ b/src/qukeys/Qukeys.h
@@ -62,7 +62,7 @@ class Plugin : public kaleidoglyph::Plugin {
     plugin_active_ = !plugin_active_;
   }
 
-  bool keyswitchEventHook(KeyswitchEvent& event,
+  bool keyswitchEventHook(KeyEvent& event,
                           kaleidoglyph::Plugin*& caller) override;
 
   void preScanHook(uint16_t current_time) override;


### PR DESCRIPTION
I'm trying to make a distinction between events that are physical-only (Keyswitch*) and the more general events that can be software-only (Key*), in advance of changing the hooks available in the event handler loop.

See gedankenlab/Kaleidoglyph-Core#14