### PR TITLE
Rewrite event queue to include release events

### DIFF
--- a/src/qukeys/EventQueue.h
+++ b/src/qukeys/EventQueue.h
@@ -1,0 +1,62 @@
+// -*- c++ -*-
+
+#include <Arduino.h>
+
+#include <kaleidoglyph/Controller.h>
+#include <kaleidoglyph/KeyAddr.h>
+#include <kaleidoglyph/KeyEvent.h>
+#include <kaleidoglyph/KeyState.h>
+#include <kaleidoglyph/utils.h>
+
+
+namespace kaleidoglyph {
+
+template <byte _max_length,
+          typename _Bitfield  = byte,
+          typename _Timestamp = uint16_t>
+class EventQueue {
+ public:
+  byte length() const { return length_; }
+  bool isEmpty() const { return (length_ == 0); }
+  bool isFull() const { return (length_ == _max_length); }
+
+  void append(KeyEvent event) {
+    addrs_[length_]      = event.addr;
+    timestamps_[length_] = Controller::scanStartTime();
+    bitWrite(release_event_bits_, length_, event.state.toggledOff());
+    ++length_;
+  }
+  void remove(byte index) {
+    --length_;
+    for (byte i{index}; i < length_; ++i) {
+      addrs_[i]      = addrs_[i + 1];
+      timestamps_[i] = timestamps_[i + 1];
+    }
+    release_event_bits_ >>= 1;
+  }
+
+  KeyAddr addr(byte index) const { return addrs_[index]; }
+
+  _Timestamp timestamp(byte index) const { return timestamps_[index]; }
+
+  bool isRelease(byte index) const {
+    return bitRead(release_event_bits_, index);
+  }
+  bool isPress(byte index) const { return !isRelease(index); }
+
+  KeyEvent head() const {
+    KeyEvent event;
+    event.addr = addrs_[0];
+    event.state =
+        bitRead(release_event_bits_, 0) ? cKeyState::release : cKeyState::press;
+    return event;
+  }
+
+ private:
+  byte       length_{0};
+  KeyAddr    addrs_[_max_length];
+  _Timestamp timestamps_[_max_length];
+  _Bitfield  release_event_bits_;
+};
+
+}  // namespace kaleidoglyph

--- a/src/qukeys/EventQueue.h
+++ b/src/qukeys/EventQueue.h
@@ -32,6 +32,19 @@ class EventQueue {
       addrs_[i]      = addrs_[i + 1];
       timestamps_[i] = timestamps_[i + 1];
     }
+    static constexpr _Bitfield all = -1;
+    _Bitfield tail_mask = all << index;
+    _Bitfield head_mask = ~tail_mask;
+    _Bitfield tail = (release_event_bits_ >> 1) & tail_mask;
+    _Bitfield head = release_event_bits_ & head_mask;
+    release_event_bits_ = tail | head;
+  }
+  void shift() {
+    --length_;
+    for (byte i{0}; i < length_; ++i) {
+      addrs_[i]      = addrs_[i + 1];
+      timestamps_[i] = timestamps_[i + 1];
+    }
     release_event_bits_ >>= 1;
   }
 

--- a/src/qukeys/Qukeys.cpp
+++ b/src/qukeys/Qukeys.cpp
@@ -20,154 +20,173 @@ namespace qukeys {
 
 // Event handler
 EventHandlerResult Plugin::onKeyswitchEvent(KeyEvent& event) {
-  // If this plugin isn't active:
-  if (! plugin_active_) {
-    if (isQukeysKey(event.key)) {
-      Qukey qukey = getQukey(event.key);
-      event.key = qukey.primaryKey();
-    }
-    return EventHandlerResult::proceed;
-  }
-
-  // If the key toggled on
-  if (event.state.toggledOn()) {
-
-    // SpaceCadet emulation; only use alternate (non-modifier) keycode if
-    // there's no rollover.
-    if (key_queue_length_ > 0) {
-      if (queue_head_qukey_.isSpaceCadet()) {
-        flushKey(false);
-      }
-    }
-
-    // If the queue is not empty or the pressed key is a qukey, add it to the
-    // queue; otherwise continue to the next event handler
-    if (key_queue_length_ > 0 || isQukeysKey(event.key)) {
-      enqueueKey(event.addr);
-      return EventHandlerResult::abort;
-    }
-    
-  } else { // event.state.toggledOff()
-
-    // If a key that was in the queue is released, flush the queue up to that
-    // key:
-    int8_t queue_index = searchQueue(event.addr);
-
-    // If we didn't find that key in the queue, continue with the next event
-    // handler:
-    if (queue_index < 0)
-      return EventHandlerResult::proceed;
-
-    // If the qukey at the head of the queue is currently delayed, we will need
-    // to send its release event later.
-    KeyEvent delayed_qukey_release;
-    if (qukey_release_delay_ != 0) {
-      delayed_qukey_release.addr = key_queue_[0].addr;
-      delayed_qukey_release.state = cKeyState::release;
-      delayed_qukey_release.caller = EventHandlerId::qukeys;
-    }
-
-    // Flush with alternate keycodes up to (but not including) the released key:
-    flushQueue(queue_index);
-
-    // At this point, the released key is now at the head of the queue. We check
-    // to see if it's a qukey:
-    if (isQukeysKey(keymap_[event.addr])) {
-
-      if (queue_head_qukey_.isSpaceCadet() && key_queue_length_ == 1) {
-        // If it's a SpaceCadet key, it should get flushed immediately. Its
-        // value depends on whether or not any subsequent keys were pressed
-        // after it.
-        flushKey(true);
-
-      } else if (overlap_required_ != 0 && key_queue_length_ > 1) {
-        // If there's a release delay in effect, and there's more than this one
-        // key in the queue, we need to abort now. The timeout(s) will be
-        // handled in the other hook. Otherwise, flush the current key with its
-        // primary value.
-        uint16_t current_time = Controller::scanStartTime();
-        uint16_t overlap_time = current_time - key_queue_[1].start_time;
-        uint32_t release_timeout = (overlap_time * 100) / overlap_required_;
-        qukey_release_delay_ = (release_timeout < 256) ? release_timeout : 255;
-        // qukey_release_delay_ = (overlap_time * 100) / overlap_required_;
-        return EventHandlerResult::abort;
-
-      } else {
-        // Otherwise, flush the qukey with its primary value.
-        flushKey(false);
-      }
-    }
-
-    // Now we can flush the remaining head of the queue of any non-qukeys:
-    flushQueue();
-
-    // Next, if there was a delayed qukey release, send its release event:
-    if (delayed_qukey_release.addr.isValid()) {
-      controller_.handleKeyEvent(delayed_qukey_release);
-    }
-
-    // Finally, we need to allow the current release event to proceed. But
-    // first, we must correct the key value from what's in the controller's
-    // active keys array:
-    event.key = controller_[event.addr];
-  }
-
-  return EventHandlerResult::proceed;
+  // if (event_queue_.isEmpty()) {
+  //   if (isQukeysKey(event.key)) {
+  //     event_queue_.append(event);
+  //     return EventHandlerResult::abort;
+  //   }
+  //   return EventHandlerResult::proceed;
+  // }
+  event_queue_.append(event);
+  processQueue();
+  return EventHandlerResult::abort;
 }
 
-
-// Check timeouts and send necessary key events
 void Plugin::preKeyswitchScan() {
+  processQueue();
 
-  // If the queue is empty, there's nothing to do:
-  if (key_queue_length_ == 0)
+  if (event_queue_.isEmpty()) {
     return;
+  }
 
-  // First, we get the current time:
-  uint16_t current_time = controller_.scanStartTime();
+  uint16_t current_time = Controller::scanStartTime();
+  uint16_t elapsed_time = current_time - event_queue_.timestamp(0);
+  if (elapsed_time < timeout) {
+    return;
+  }
+  KeyEvent event = event_queue_.head();
+  Qukey qukey = getQukey(keymap_[event.addr]);
+  event.key = qukey.isSpaceCadet() ? qukey.primaryKey() : qukey.alternateKey();
+  event.caller = EventHandlerId::qukeys;
+  event_queue_.remove(0);
+  controller_.handleKeyEvent(event);
+}
 
-  // Next, we check the first key in the queue for delayed release
-  if (qukey_release_delay_ > 0 && key_queue_length_ > 1) {
-    uint16_t elapsed_time = current_time - key_queue_[1].start_time;
-    if (elapsed_time > qukey_release_delay_) {
-      // prepare release event
-      KeyEvent event;
-      event.addr  = key_queue_[0].addr;
-      event.state = cKeyState::release;
-      event.caller = EventHandlerId::qukeys;
-      // press qukey primary
-      flushQueue(false);
-      // send the release event
-      controller_.handleKeyEvent(event);
-    }
-  } else {
-    // If there was no delayed release, we check to see if the qukey at the head
-    // of the queue has timed out.
-    uint16_t elapsed_time = current_time - key_queue_[0].start_time;
-    if (elapsed_time > timeout) {
-      if (queue_head_qukey_.isSpaceCadet()) {
-        flushQueue(false);  // primary
-      } else {
-        flushQueue(true);  // alternate
-      }
-    }
+void Plugin::processQueue() {
+  KeyEvent event;
+  while (updateFlushEvent(event)) {
+    event.caller = EventHandlerId::qukeys;
+    controller_.handleKeyEvent(event);
   }
 }
 
-
-// returning a pointer is an experiment here; maybe its better to return the index
-inline
-const Qukey* Plugin::lookupQukey(Key key) {
-  if (QukeysKey::verifyType(key)) {
-    byte qukey_index = QukeysKey(key).data();
-    if (qukey_index < qukey_count_)
-      return &qukeys_[qukey_index];
+bool Plugin::updateFlushEvent(KeyEvent& queued_event) {
+  if (event_queue_.isEmpty()) {
+    return false;
   }
-  return nullptr;
+  queued_event = event_queue_.head();
+
+  // If the first event in the queue is a release, flush it immediately.
+  if (queued_event.state.toggledOff()) {
+    event_queue_.remove(0);
+    return true;
+  }
+  // The first event in the queue is a press, so look up its value in the
+  // keymap. If it's not a QukeysKey, we can flush it now.
+  queued_event.key = keymap_[queued_event.addr];
+  if (!isQukeysKey(queued_event.key)) {
+    event_queue_.remove(0);
+    return true;
+  }
+
+  // Now the first event in the queue is a QukeysKey press, so we look up its
+  // corresponding Qukey, and record whether or not it's a SpaceCadet key for
+  // use later.
+  Qukey qukey = getQukey(queued_event.key);
+
+  // If Qukeys is turned off, translate the QukeysKey at the head of the queue
+  // to its primary value (regardless of whether or not it's a SpaceCadet key),
+  // then flush it from the queue.
+  if (! plugin_active_) {
+    queued_event.key = qukey.primaryKey();
+    event_queue_.remove(0);
+    return true;
+  }
+
+  // This is the queue index of the next keypress subsequent to the press of the
+  // qukey at the head of the queue. If it's zero, that means there haven't been
+  // any at the time of the event we're looking at.
+  byte next_keypress_index{0};
+
+  // To make the following code slightly more efficient, record whether or not
+  // the qukey at the head of the queue is a SpaceCadet key.
+  bool qukey_is_spacecadet = qukey.isSpaceCadet();
+
+  // Now we walk down the queue, and determine the state of the qukey, if there
+  // have been any events that cause it to become either primary or alternate.
+  for (byte i{1}; i < event_queue_.length(); ++i) {
+    // First deal with key press events:
+    if (event_queue_.isPress(i)) {
+      if (qukey_is_spacecadet) {
+        queued_event.key = qukey.primaryKey();
+        event_queue_.remove(0);
+        return true;
+      }
+      if (next_keypress_index == 0) {
+        next_keypress_index = i;
+      }
+      continue;
+    }
+    // event_queue_[i] is a release event
+
+    // If this is a release of the qukey
+    if (event_queue_.addr(i) == queued_event.addr) {
+      if (next_keypress_index == 0 || overlap_required_ == 0) {
+        // there were no keypresses between the qukey press and its release, or
+        // there's no release delay overlap configured.
+        queued_event.key = qukey_is_spacecadet ? qukey.alternateKey() : qukey.primaryKey();
+        event_queue_.remove(0);
+        return true;
+      }
+      // calculate release delay and check to see if it has timed out
+      uint16_t overlap_start = event_queue_.timestamp(next_keypress_index);
+      uint16_t overlap_end = event_queue_.timestamp(i);
+      if (releaseDelayed(overlap_start, overlap_end)) {
+        continue;
+      }
+      queued_event.key = qukey.primaryKey();
+      event_queue_.remove(0);
+      return true; 
+    }
+
+    for (byte j{1}; j < i; ++j) {
+      if (event_queue_.isPress(j) &&
+          event_queue_.addr(j) == event_queue_.addr(i)) {
+        // event_queue_[i] is a release of a key that was pressed subsequent
+        // to the qukey
+        queued_event.key = qukey.alternateKey();
+        event_queue_.remove(0);
+        return true;
+      }
+    }
+
+    // A key was released that is not in the queue. If it's not a modifier key
+    // (including layer shifts), we send the release event out of order:
+    KeyAddr k = event_queue_.addr(i);
+    Key key = controller_[k];
+    if (! (isModifierKey(key) || isLayerShiftKey(key))) {
+      queued_event.addr = k;
+      queued_event.key = key;
+      queued_event.state = cKeyState::release;
+      event_queue_.remove(i);
+      return true;
+    }
+  }
+
+  // The queue must always have space for the next event to be added, so if it's
+  // still full at this point, we need to flush the qukey. The safest thing to
+  // do is to use the primary keycode, because someone is probably mashing on
+  // the keys.
+  if (event_queue_.isFull()) {
+    queued_event.key = qukey.primaryKey();
+    event_queue_.remove(0);
+    return true;
+  }
+
+  // Return empty (invalid) event as signal to wait.
+  return false;
+}
+
+bool Plugin::releaseDelayed(uint16_t overlap_start, uint16_t overlap_end) const {
+  uint16_t overlap_duration = overlap_end - overlap_start;
+  uint32_t limit = (overlap_duration * 100) / overlap_required_;
+  byte release_timeout = (limit < 256) ? limit : 255;
+  uint16_t current_time = Controller::scanStartTime();
+  uint16_t elapsed_time = current_time - overlap_start;
+  return (elapsed_time < release_timeout);
 }
 
 // return the Qukey object corresponding to the QukeysKey
-inline
 Qukey Plugin::getQukey(Key key) const {
   assert(isQukeysKey(key));
 
@@ -178,114 +197,6 @@ Qukey Plugin::getQukey(Key key) const {
   // We should never get here, but there's nothing stopping the sketch from
   // having a QukeysKey with index data that's out of bounds.
   return Qukey{};
-}
-
-bool Plugin::isQukey(KeyAddr k) const {
-  Key key = keymap_[k];
-  return isQukeysKey(key);
-}
-
-inline
-const Qukey* Plugin::lookupQukey(KeyAddr k) {
-  return lookupQukey(keymap_[k]);
-}
-
-inline
-const Qukey* Plugin::lookupQukey(QueueEntry entry) {
-  return lookupQukey(entry.addr);
-}
-
-// Add a keypress event to the queue while we wait for a qukey's state to be decided
-inline
-void Plugin::enqueueKey(KeyAddr k) {
-  if (key_queue_length_ == queue_max) {
-    flushQueue(false); // false => primary key
-  }
-  key_queue_[key_queue_length_].addr       = k;
-  key_queue_[key_queue_length_].start_time = Controller::scanStartTime();
-  if (key_queue_length_ == 0) {
-    queue_head_qukey_ = getQukey(keymap_[k]);
-  }
-  ++key_queue_length_;
-}
-
-// Search the queue for a given KeyAddr; return index if found, -1 if not
-inline
-int8_t Plugin::searchQueue(KeyAddr k) {
-  for (byte i{0}; i < key_queue_length_; ++i) {
-    if (key_queue_[i].addr == k)
-      return i;
-  }
-  return -1; // not found
-}
-
-// helper function
-inline
-QueueEntry Plugin::shiftQueue() {
-  QueueEntry entry = key_queue_[0];
-  --key_queue_length_;
-  for (byte i{0}; i < key_queue_length_; ++i) {
-    key_queue_[i] = key_queue_[i + 1]; // check if more efficient to increment here instead of above
-  }
-  return entry;
-}
-
-// flush the first key, with the specified keycode
-inline
-void Plugin::flushKey(bool use_alternate_key) {
-  assert(key_queue_length_ > 0);
-
-  QueueEntry entry = shiftQueue();
-
-  KeyEvent event;
-  event.addr  = entry.addr;
-  event.state = cKeyState::press;
-  event.caller = EventHandlerId::qukeys;
-  event.key = keymap_[entry.addr];
-
-  if (isQukeysKey(event.key)) {
-    if (use_alternate_key) {
-      event.key = queue_head_qukey_.alternateKey();
-    } else {
-      event.key = queue_head_qukey_.primaryKey();
-    }
-  }
-
-  // Send the keypress event for the flushed key:
-  controller_.handleKeyEvent(event);
-
-  // If the queue isn't empty, cache the next entry's Qukey value (if it is a
-  // qukey):
-  if (key_queue_length_ > 0) {
-    KeyAddr k = key_queue_[0].addr;
-    queue_head_qukey_ = getQukey(keymap_[k]);
-  }
-
-  // Clear any release delay that had been set
-  qukey_release_delay_ = 0;
-}
-
-// Flush any non-qukeys from the beginning of the queue
-inline
-void Plugin::flushQueue() {
-  while (key_queue_length_ > 0 && !isQukeysKey(keymap_[key_queue_[0].addr])) {
-    flushKey();
-  }
-}
-
-inline
-void Plugin::flushQueue(bool alt_key) {
-  flushKey(alt_key);
-  flushQueue();
-}
-
-// flush keys up to (but not including) index. qukeys => alternate
-inline
-void Plugin::flushQueue(int8_t queue_index) {
-  while (queue_index > 0) {
-    flushKey(true);
-    --queue_index;
-  }
 }
 
 } // namespace qukeys {

--- a/src/qukeys/Qukeys.cpp
+++ b/src/qukeys/Qukeys.cpp
@@ -24,10 +24,11 @@ EventHandlerResult Plugin::onKeyswitchEvent(KeyEvent& event) {
   // queue and abort; the processing of the queue now happens in the pre-scan
   // hook instead. I tried including tests here for events that could bypass the
   // event queue, but it increases the size of the binary by more than seems
-  // worthwhile (66 bytes). Similarly, I had included a call to `processQueue()`
-  // after the event gets queued, but that happens in the pre-scan hook anyway,
-  // so it saves another 6 bytes of PROGMEM.
+  // worthwhile (66 bytes).
   event_queue_.append(event);
+  // This seemingly-unnecessary call guarantees that the queue can't overflow,
+  // even if we get multiple events in a single scan cycle.
+  processQueue();
   return EventHandlerResult::abort;
 }
 

--- a/src/qukeys/Qukeys.cpp
+++ b/src/qukeys/Qukeys.cpp
@@ -151,7 +151,11 @@ bool Plugin::updateFlushEvent(KeyEvent& queued_event) {
     }
 
     // A key was released that is not in the queue. If it's not a modifier key
-    // (including layer shifts), we send the release event out of order:
+    // (including layer shifts), we send the release event out of order. Without
+    // this block of code, the binary is 30 bytes smaller, but there's a chance
+    // of delaying a release long enough that it repeats, despite the user
+    // having tapped the key. Also, the queue is more likely to overflow,
+    // requiring a premature release of a qukey.
     KeyAddr k = event_queue_.addr(i);
     Key key = controller_[k];
     if (! (isModifierKey(key) || isLayerShiftKey(key))) {

--- a/src/qukeys/constants.h
+++ b/src/qukeys/constants.h
@@ -18,17 +18,5 @@ constexpr byte queue_max{8};
 // flushed before the timeout expires.
 constexpr uint16_t timeout{200};
 
-// For people who are in the habit of simultaneously releasing modifiers with the target
-// key (the one to be modified), a release delay can be set. This means that if the qukey
-// release is detected first, it won't be flushed from the queue immediately, but will
-// wait until this delay expires (in milliseconds) before flushing the qukey in its
-// primary state. If, before that happens, the target key's release is detected, it will
-// instead get flushed in its alternate state. This is a global default value that will
-// apply to all qukeys, but which can be overridden in each Qukey instance. Note that
-// setting this value too high (>20ms is not recommended) can result in unintended
-// alternate keycodes (i.e. modifiers) during rollover when typing, which is probably
-// worse than unintended primary keycodes.
-constexpr byte qukey_release_delay{0};
-
 } // namespace qukeys {
 } // namespace kaleidoglyph {


### PR DESCRIPTION
This is a major rewrite of Qukeys. It now uses a new `EventQueue` structure to store both press and release events in order, only allowing non-modifier events to be released out of order (both to keep the queue shorter and to guard against releases being delayed long enough to result in repeated characters). The hook functions themselves are now greatly simplified, and the logic has been almost completely reorganized, with the vast bulk of it now in the `updateFlushEvent()` function (which I'm hoping to find a better name for.

Fixes #12