### PR TITLE
Add tap-hold feature

### DIFF
--- a/src/qukeys/EventQueue.h
+++ b/src/qukeys/EventQueue.h
@@ -49,6 +49,10 @@ class EventQueue {
     }
     release_event_bits_ >>= 1;
   }
+  void clear() {
+    length_ = 0;
+    release_event_bits_ = 0;
+  }
 
   KeyAddr addr(byte index) const { return addrs_[index]; }
 

--- a/src/qukeys/Qukeys.cpp
+++ b/src/qukeys/Qukeys.cpp
@@ -38,7 +38,7 @@ void Plugin::preKeyswitchScan() {
   processQueue();
 
   // After that, if there's nothing left in the queue, we're done.
-  if (event_queue_.isEmpty()) {
+  if (event_queue_.isEmpty() || release_delayed_for_tap_hold_) {
     return;
   }
 
@@ -274,13 +274,12 @@ bool Plugin::waitingForTapHold() {
       // There's nothing left in the queue, and we're not technically waiting to
       // decide on a tap-hold, but we need to return true here anyway as a
       // signal that processing of the queue should stop because it's empty.
-      return true;
     }
+    return true;
   }
 
   // If we get here, there are three (or possibly more) events in the queue, so
   // the qukey has been tapped twice.
-  release_delayed_for_tap_hold_ = false;
   return false;
 }
 

--- a/src/qukeys/Qukeys.h
+++ b/src/qukeys/Qukeys.h
@@ -120,12 +120,16 @@ class Plugin : public kaleidoglyph::Plugin {
   // alternate value
   byte overlap_required_{99};
 
+  // If a tap-hold sequence hasn't been cancelled or timed out yet
+  bool release_delayed_for_tap_hold_{false};
+
   // Runtime controls
   bool plugin_active_{true};
 
   void processQueue();
   bool updateFlushEvent(KeyEvent& queued_event);
   bool releaseDelayed(uint16_t overlap_start, uint16_t overlap_end) const;
+  bool waitingForTapHold();
   Qukey getQukey(Key key) const;
 };
 

--- a/src/qukeys/constants.h
+++ b/src/qukeys/constants.h
@@ -18,5 +18,14 @@ constexpr byte queue_max{8};
 // flushed before the timeout expires.
 constexpr uint16_t hold_timeout{200};
 
+// To enable the tap-hold feature, we need another timeout value. When a qukey
+// is tapped, it's release event will be delayed by this amount. If it is tapped
+// again before that timeout, the release event will again be delayed by the
+// same amount (after the second press). If the qukey hasn't been released by
+// the second timeout, the first release event and the second press event will
+// be ignored, and the keyboard will behave as if the key was simply pressed and
+// held since the initial press event.
+constexpr byte tap_hold_timeout{200};
+
 } // namespace qukeys {
 } // namespace kaleidoglyph {


### PR DESCRIPTION
This feature provides a way for the user to hold the "tap" value of a Qukey, by quickly tapping and holding the key on its own. This might be thought of as a "double-tap-hold", because there are two presses, but I've mostly been reserving the term "tap" to mean a press followed quickly by a release.

With this feature, the release event for a tapped qukey gets delayed briefly. If the same key is pressed during that delay window, then held long enough, the first release event and the second press event will both get ignored, and it will behave as if the user simply pressed and held the key once.